### PR TITLE
Add delay between calendar insertions to avoid bug ⚡

### DIFF
--- a/functions/calendar/calendar.js
+++ b/functions/calendar/calendar.js
@@ -39,11 +39,18 @@ const addEventToCalendar = (event) =>
  * @param events an array of events to be added.
  */
 const addEventsToCalendar = async (events) => {
-  events.forEach(async event => {
-    addEventToCalendar(event)
+  var currentEvent = 0;
+  const interval = setInterval(async function(){
+    if (currentEvent >= events.length) {
+      clearInterval(interval);
+    } else {
+      var event = events[currentEvent];
+      await addEventToCalendar(event)
       .then(_ => query.markSeen(event.stub))
+      .finally(_ => currentEvent++)
       .catch(err => console.log(err));
-  });
+    }
+  }, 4000);
 }
 
 const deleteEvent = (calendarId, eventId) =>


### PR DESCRIPTION
Fixes a bug `GaxiosError` caused by too many API calls, resulting in the `Rate Limit` to be exceeded and no calendar events being made.